### PR TITLE
I'm trying to add a new set of interfaces

### DIFF
--- a/new/API.proto
+++ b/new/API.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+import "base.proto";
+import "command.proto";
+import "referee.proto";
+
+message RefereeCall {
+    // Referee service has two methods
+    oneof method {
+        JudgeCall judge = 1;
+        JudgePlacementCall judge_placement = 2;
+    }
+
+    // Determine if the `env` is a foul.
+    message JudgeCall {
+        Environment env = 1;
+    }
+
+    // Find invalid position in `env` and try to fix it.
+    // Referee judge the placement indicated by `env` argument,
+    // and the `foul_info` argument created by referee indicates
+    // the reason of foul.
+    message JudgePlacementCall {
+        Environment env = 1;
+        FoulInfo foul_info = 2;
+    }
+
+    // Result of JudgeCall
+    message JudgeResult {
+        FoulInfo foul_info = 1;
+    }
+
+    // Result of JudgePlacementCall
+    message JudgePlacementResult {
+        PlacementFoulInfo foul_info = 1;
+    }
+}
+
+message StrategyCall {
+    // Strategy service has two methods
+    oneof method {
+        GetWheelCall get_wheel = 1;
+        GetPlacementCall get_placement = 2;
+    }
+
+    // Control robots' actions based on `Environment`.
+    message GetWheelCall {
+        Environment env = 1;
+    }
+
+    // Control robots' placements based on `env` and `foul_info`.
+    // The `foul_info` argument includes the frame caused the foul.
+    message GetPlacementCall {
+        Environment env = 1;
+        FoulInfo foul_info = 2;
+    }
+
+    // Result of GetWheelCall
+    message GetWheelResult {
+        WheelControl wheel = 1;
+    }
+
+    // Result of GetPlacementCall
+    message GetPlacementResult {
+        PlacementControl placement = 1;
+    }
+}

--- a/new/base.proto
+++ b/new/base.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+enum Who {
+    Blue = 0;
+    Yellow = 1;
+}
+
+message Ball {
+    float x = 1;
+    float y = 2;
+    // float z = 3;
+}
+
+message Robot {
+    int32 id = 1;
+    float x = 2;
+    float y = 3;
+    float rotation = 4;
+}
+
+message Environment {
+    Ball ball = 1;
+    repeated Robot robots_blue = 2;
+    repeated Robot robots_yellow = 3;
+}

--- a/new/command.proto
+++ b/new/command.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+import "base.proto";
+
+// Messages that strategy sends to platform in order to control robots.
+
+message WheelSpeed {
+    int32 robot_id = 1;
+    float wheel_right = 2;
+    float wheel_left = 3;
+}
+
+message WheelControl {
+    repeated WheelSpeed control = 1;
+}
+
+message PlacementControl {
+    Ball ball = 1;
+    repeated Robot robots = 2;
+}

--- a/new/referee.proto
+++ b/new/referee.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+import "base.proto";
+
+// Messages that referee sends to platform.
+
+message FoulInfo {
+    enum FoulType {
+        PlayOn = 0;
+        FreeBallTop = 1;
+        FreeBallBot = 2;
+        PlaceKick = 3;
+        PenaltyKick = 4;
+        FreeKick = 5;
+        GoalKick = 6;
+    }
+
+    // PlayOn indicated running and other indicated foul.
+    FoulType type = 1;
+    // If type is not PlayOn, actor means who caused the foul.
+    Who actor = 2;
+    // Foul details.
+    string Reason = 3;
+}
+
+message PlacementError {
+    string error_str = 1;
+    Who whose = 2;
+}
+
+message PlacementFoulInfo {
+    // Errors in placement passed in detected by referee.
+    repeated PlacementError error = 1;
+    // Placement corrected by referee.
+    Environment corrected_placement = 2;
+}


### PR DESCRIPTION
# New Architecture

I created a new architecture to simplify the connections between platform, strategy and referee. The core idea is let strategy and referee be services server for platform. The strategy service offers robots' command and the referee offer foul determinations. And they are all requested by platform so there is no connection between referee and strategy. In other words, services are 'static' and drived by platform. They just provide some data according platform's input.

The new architecture like this:

```
+-------------+         +------------------+
|             |         |                  |
|          +--------------->               |
|             |         |     strategy     |
|          <---------------+  service      |
|             |         |                  |
|             |         +------------------+
|  platform   |
|             |         +------------------+
|             |         |                  |
|          +--------------->               |
|             |         |     referee      |
|          <---------------+  service      |
|             |         |                  |
+-------------+         +------------------+

```

# File Description

All file is in new folder.

- new/API.proto

Including RPC calls' definitions of referee service and strategy service.

- new/base.proto

Including base structures like `Environment`.

- new/command.proto

Including structures required by strategy service.

- new/referee.proto

Including structures required by referee service.

