### PR TITLE
Fix for C++ code generation

### DIFF
--- a/REF2CLI/messages.proto
+++ b/REF2CLI/messages.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option csharp_namespace = "FiraSim.Referee.Proto.RefToCli";
+package fira_message.ref_to_cli;
 
 import "common.proto";
 

--- a/REF2CLI/messages.proto
+++ b/REF2CLI/messages.proto
@@ -14,13 +14,12 @@ enum Color{
 }
 
 enum Side{
-    Left = 0;
-    Right = 1;
+    Self = 0;
+    Opponent = 1;
 }
 
 message TeamInfo{
     Color color = 1;
-    Side side = 2;
 }
 
 message Robots{
@@ -35,16 +34,27 @@ message Environment{
 message FoulInfo {
     enum FoulType {
         PlayOn = 0;
-        FreeBallTop = 1;
-        FreeBallBot = 2;
         PlaceKick = 3;
         PenaltyKick = 4;
         FreeKick = 5;
         GoalKick = 6;
+        FreeBallLeftTop = 7;
+        FreeBallRightTop = 8;
+        FreeBallLeftBot = 9;
+        FreeBallRightBot = 10;
     }
 
-    FoulType type = 1;
-    Side actor = 2;
+    enum PhaseType {
+        FirstHalf = 0;
+        SecondHalf = 1;
+        Overtime = 2;
+        PenaltyShootout = 3;
+    }
+
+    PhaseType phase = 1;
+
+    FoulType type = 2;
+    Side actor = 3;
 }
 
 message WheelSpeed {

--- a/REF2CLI/messages.proto
+++ b/REF2CLI/messages.proto
@@ -49,6 +49,7 @@ message FoulInfo {
         SecondHalf = 1;
         Overtime = 2;
         PenaltyShootout = 3;
+        Stopped = 4;
     }
 
     PhaseType phase = 1;

--- a/REF2CLI/messages.proto
+++ b/REF2CLI/messages.proto
@@ -8,23 +8,19 @@ message TeamName {
     string name = 1;
 }
 
+enum Color{
+    Y = 0;
+    B = 1;
+}
+
+enum Side{
+    Left = 0;
+    Right = 1;
+}
+
 message TeamInfo{
-    string name = 1;
-
-    enum color{
-        Y = 0;
-        B = 1;
-    }
-
-    enum side{
-        LEFT = 0;
-        RIGHT = 1;
-    }
-
-    enum status{
-        NOK = 0;
-        OK = 1;
-    }
+    Color color = 1;
+    Side side = 2;
 }
 
 message Robots{
@@ -46,6 +42,9 @@ message FoulInfo {
         FreeKick = 5;
         GoalKick = 6;
     }
+
+    FoulType type = 1;
+    Side actor = 2;
 }
 
 message WheelSpeed {

--- a/REF2CLI/service.proto
+++ b/REF2CLI/service.proto
@@ -6,14 +6,14 @@ import "common.proto";
 option csharp_namespace = "FiraSim.Referee.Proto.RefToCli";
 
 service Referee {
-  rpc runStrategy (Environment) returns (Command) {}
-  rpc setBall (Environment) returns (Ball) {}
-  rpc setFormerRobots(Environment) returns (Robots) {}
-  rpc setLaterRobots(Environment) returns(Robots) {}
+  rpc RunStrategy (Environment) returns (Command) {}
+  rpc SetBall (Environment) returns (Ball) {}
+  rpc SetFormerRobots(Environment) returns (Robots) {}
+  rpc SetLaterRobots(Environment) returns(Robots) {}
 }
 
 
 service Register {
-  rpc register (TeamName) returns (TeamInfo) {}
+  rpc Register (TeamName) returns (TeamInfo) {}
 }
 

--- a/REF2CLI/service.proto
+++ b/REF2CLI/service.proto
@@ -14,6 +14,6 @@ service Referee {
 
 
 service Register {
-  rpc Register (TeamName) returns (TeamInfo) {}
+  rpc Register (TeamInfo) returns (TeamName) {}
 }
 

--- a/REF2CLI/service.proto
+++ b/REF2CLI/service.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "REF2CLI/messages.proto";
 import "common.proto";
 
-option csharp_namespace = "FiraSim.Referee.Proto.RefToCli";
+package fira_message.ref_to_cli;
 
 service Referee {
   rpc RunStrategy (Environment) returns (Command) {}

--- a/REF2CLI/service.proto
+++ b/REF2CLI/service.proto
@@ -6,14 +6,12 @@ import "common.proto";
 package fira_message.ref_to_cli;
 
 service Referee {
+  rpc Register (TeamInfo) returns (TeamName) {}
+
   rpc RunStrategy (Environment) returns (Command) {}
   rpc SetBall (Environment) returns (Ball) {}
   rpc SetFormerRobots(Environment) returns (Robots) {}
   rpc SetLaterRobots(Environment) returns(Robots) {}
 }
 
-
-service Register {
-  rpc Register (TeamInfo) returns (TeamName) {}
-}
 

--- a/SIM2REF/command.proto
+++ b/SIM2REF/command.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package fira_message.sim_to_ref
+package fira_message.sim_to_ref;
 
 message Command {
 	uint32 id          = 1;

--- a/SIM2REF/command.proto
+++ b/SIM2REF/command.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option csharp_namespace = "FiraSim.Referee.Proto.SimToRef";
+package fira_message.sim_to_ref
 
 message Command {
 	uint32 id          = 1;

--- a/SIM2REF/packet.proto
+++ b/SIM2REF/packet.proto
@@ -4,7 +4,7 @@ import "SIM2REF/command.proto";
 import "SIM2REF/replacement.proto";
 import "common.proto";
 
-package fira_message.sim_to_ref
+package fira_message.sim_to_ref;
 
 message Packet {
 	Commands    cmd     = 1;

--- a/SIM2REF/packet.proto
+++ b/SIM2REF/packet.proto
@@ -18,5 +18,5 @@ message Environment {
 }
 
 service Simulate {
-	rpc simulate (Packet) returns (Environment) {}
+	rpc Simulate (Packet) returns (Environment) {}
 }

--- a/SIM2REF/packet.proto
+++ b/SIM2REF/packet.proto
@@ -4,7 +4,7 @@ import "SIM2REF/command.proto";
 import "SIM2REF/replacement.proto";
 import "common.proto";
 
-option csharp_namespace = "FiraSim.Referee.Proto.SimToRef";
+package fira_message.sim_to_ref
 
 message Packet {
 	Commands    cmd     = 1;

--- a/SIM2REF/replacement.proto
+++ b/SIM2REF/replacement.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option csharp_namespace = "FiraSim.Referee.Proto.SimToRef";
+package fira_message.sim_to_ref
 
 import "common.proto";
 

--- a/SIM2REF/replacement.proto
+++ b/SIM2REF/replacement.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package fira_message.sim_to_ref
+package fira_message.sim_to_ref;
 
 import "common.proto";
 

--- a/common.proto
+++ b/common.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 
-package fira_message
-option csharp_namespace = "FiraMessage";
+package fira_message;
 
 message Ball {
     double x = 1;

--- a/common.proto
+++ b/common.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
-option csharp_namespace = "FiraSim.Referee.Proto";
+package fira_message
+option csharp_namespace = "FiraMessage";
 
 message Ball {
     double x = 1;


### PR DESCRIPTION
Changes:
- Replace C# specific options with general `package` declarations.
- Capitalize rpc method to avoid conflict with C++ keywords.